### PR TITLE
maintenance update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.11-slim-bookworm
 
+RUN apt-get update && apt-get install -y curl iputils-ping && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 ARG BUILD_TYPE
 COPY requirements.txt /
 

--- a/appinfo/info-latest.xml
+++ b/appinfo/info-latest.xml
@@ -6,7 +6,7 @@
 	<description>
 	<![CDATA[Application to test the Docker AppAPI deployment process]]>
 	</description>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<licence>MIT</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -17,7 +17,7 @@
 	<bugs>https://github.com/nextcloud/app_api/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/test-deploy</repository>
 	<dependencies>
-		<nextcloud min-version="28" max-version="31"/>
+		<nextcloud min-version="28" max-version="32"/>
 	</dependencies>
 	<external-app>
 		<docker-install>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description>
 	<![CDATA[Application to test the Docker AppAPI deployment process]]>
 	</description>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<licence>MIT</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -17,7 +17,7 @@
 	<bugs>https://github.com/nextcloud/app_api/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/test-deploy</repository>
 	<dependencies>
-		<nextcloud min-version="28" max-version="31"/>
+		<nextcloud min-version="28" max-version="32"/>
 	</dependencies>
 	<external-app>
 		<docker-install>

--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -47,7 +47,11 @@ def report_init_status() -> None:
         print(f"Try send request using HTTP instead of HTTPS: {nextcloud_url}", flush=True)
         try:
             r = httpx.get(
-                nextcloud_url.rstrip("/") + "/ocs/v1.php/cloud/capabilities", headers={"OCS-APIRequest": "true"}
+                nextcloud_url.rstrip("/") + "/ocs/v1.php/cloud/capabilities",
+                headers={
+                    "OCS-APIRequest": "true",
+                    "User-Agent": f"ExApp/{nc.app_cfg.app_name}/{nc.app_cfg.app_version} (httpx/{httpx.__version__})",
+                }
             )
             if httpx.codes.is_error(r.status_code):
                 print("Unsuccessful. Can not determine correct URL of the Nextcloud instance.", flush=True)

--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -51,7 +51,7 @@ def report_init_status() -> None:
                 headers={
                     "OCS-APIRequest": "true",
                     "User-Agent": f"ExApp/{nc.app_cfg.app_name}/{nc.app_cfg.app_version} (httpx/{httpx.__version__})",
-                }
+                },
             )
             if httpx.codes.is_error(r.status_code):
                 print("Unsuccessful. Can not determine correct URL of the Nextcloud instance.", flush=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-nc_py_api[app]>=0.17.1
+nc_py_api[app]>=0.18.2


### PR DESCRIPTION
This PR updates `nc-py-api` to the latest version, which has fixes for support of **self-signed certificates** and a custom **UserAgent** for ExApps

In addition, the "curl" and "ping" commands have been added to the container to make it easier.

Installation on the 32 version of Nextcloud is also allowed, since the master branch there will soon become this version.