### PR TITLE
support for Blackwell; support for build from src using Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm AS builder
+FROM docker.io/python:3.12-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -27,13 +27,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then \
         echo "Installing PyTorch for ARM64"; \
-        python3 -m pip install --root-user-action=ignore torch==2.4.1 torchvision torchaudio; \
+        python3 -m pip install --root-user-action=ignore torch==2.8.0 torchvision; \
     elif [ "$BUILD_TYPE" = "rocm" ]; then \
-        python3 -m pip install --root-user-action=ignore torch==2.4.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.1; \
+        python3 -m pip install --root-user-action=ignore torch==2.8.0 torchvision --index-url https://download.pytorch.org/whl/rocm6.4; \
     elif [ "$BUILD_TYPE" = "cpu" ]; then \
-        python3 -m pip install --root-user-action=ignore torch==2.4.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu; \
+        python3 -m pip install --root-user-action=ignore torch==2.8.0 torchvision --index-url https://download.pytorch.org/whl/cpu; \
     else \
-        python3 -m pip install --root-user-action=ignore torch==2.4.1 torchvision torchaudio; \
+        python3 -m pip install --root-user-action=ignore torch==2.8.0 torchvision; \
     fi
 
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -46,11 +46,7 @@ COPY --from=builder /usr/local/ /usr/local/
 RUN apt-get update && apt-get install -y curl procps iputils-ping netcat-traditional && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ADD /ex_app/cs[s] /ex_app/css
-ADD /ex_app/im[g] /ex_app/img
-ADD /ex_app/j[s] /ex_app/js
-ADD /ex_app/l10[n] /ex_app/l10n
-ADD /ex_app/li[b] /ex_app/lib
+ADD /ex_app/lib /ex_app/lib
 
 COPY --chmod=775 healthcheck.sh /
 COPY --chmod=775 start.sh /

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,15 @@ help:
 	@echo " "
 	@echo "  build-push          builds app docker images with 'release' tags and uploads them to ghcr.io"
 	@echo "  build-push-latest   builds app docker images with 'latest' tags and uploads them to ghcr.io"
+	@echo "  build-podman-latest builds app docker images with 'latest' tags with podman"
 	@echo " "
 	@echo "  > Next commands are only for the dev environment with nextcloud-docker-dev!"
 	@echo "  > They must be run from the host you are developing on, not in a Nextcloud container!"
 	@echo " "
-	@echo "  run30               installs $(APP_NAME) for Nextcloud 30"
+	@echo "  run31               installs $(APP_NAME) for Nextcloud 31"
 	@echo "  run                 installs $(APP_NAME) for Nextcloud Latest"
 	@echo " "
-	@echo "  run30-latest        installs $(APP_NAME) with 'latest' tag for Nextcloud 30"
+	@echo "  run31-latest        installs $(APP_NAME) with 'latest' tag for Nextcloud 31"
 	@echo "  run-latest          installs $(APP_NAME) with 'latest' tag for Nextcloud Latest"
 
 .PHONY: build-push
@@ -37,9 +38,15 @@ build-push-latest:
 	DOCKER_BUILDKIT=1 docker buildx build --progress=plain --push --platform linux/amd64 --tag ghcr.io/nextcloud/$(APP_ID):latest-cuda --build-arg BUILD_TYPE=cuda .
 	DOCKER_BUILDKIT=1 docker buildx build --progress=plain --push --platform linux/amd64 --tag ghcr.io/nextcloud/$(APP_ID):latest-rocm --build-arg BUILD_TYPE=rocm .
 
-.PHONY: run30
-run30:
-	docker exec master-stable30-1 sudo -u www-data php occ app_api:app:register $(APP_ID) --test-deploy-mode \
+.PHONY: build-podman-latest
+build-push-latest:
+	podman build --format=docker --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/nextcloud/$(APP_ID):latest --build-arg BUILD_TYPE=cpu .
+	podman build --format=docker --platform linux/amd64 --tag ghcr.io/nextcloud/$(APP_ID):latest-cuda --build-arg BUILD_TYPE=cuda .
+	podman build --format=docker --platform linux/amd64 --tag ghcr.io/nextcloud/$(APP_ID):latest-rocm --build-arg BUILD_TYPE=rocm .
+
+.PHONY: run31
+run31:
+	docker exec master-stable31-1 sudo -u www-data php occ app_api:app:register $(APP_ID) --test-deploy-mode \
 		--info-xml https://raw.githubusercontent.com/nextcloud/$(APP_ID)/main/appinfo/info.xml
 
 .PHONY: run
@@ -47,9 +54,9 @@ run:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register $(APP_ID) --test-deploy-mode \
 		--info-xml https://raw.githubusercontent.com/nextcloud/$(APP_ID)/main/appinfo/info.xml
 
-.PHONY: run30-latest
-run30-latest:
-	docker exec master-stable30-1 sudo -u www-data php occ app_api:app:register $(APP_ID) --test-deploy-mode \
+.PHONY: run31-latest
+run31-latest:
+	docker exec master-stable31-1 sudo -u www-data php occ app_api:app:register $(APP_ID) --test-deploy-mode \
 		--info-xml https://raw.githubusercontent.com/nextcloud/$(APP_ID)/main/appinfo/info-latest.xml
 
 .PHONY: run-latest

--- a/appinfo/info-latest.xml
+++ b/appinfo/info-latest.xml
@@ -6,7 +6,7 @@
 	<description>
 	<![CDATA[Application to test the Docker AppAPI deployment process]]>
 	</description>
-	<version>2.0.1</version>
+	<version>2.1.0</version>
 	<licence>MIT</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -17,7 +17,7 @@
 	<bugs>https://github.com/nextcloud/app_api/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/test-deploy</repository>
 	<dependencies>
-		<nextcloud min-version="32" max-version="32"/>
+		<nextcloud min-version="30" max-version="33"/>
 	</dependencies>
 	<external-app>
 		<docker-install>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description>
 	<![CDATA[Application to test the Docker AppAPI deployment process]]>
 	</description>
-	<version>1.1.0</version>
+	<version>1.2.0</version>
 	<licence>MIT</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -17,7 +17,7 @@
 	<bugs>https://github.com/nextcloud/app_api/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/test-deploy</repository>
 	<dependencies>
-		<nextcloud min-version="28" max-version="32"/>
+		<nextcloud min-version="30" max-version="33"/>
 	</dependencies>
 	<external-app>
 		<docker-install>
@@ -25,8 +25,5 @@
 			<image>nextcloud/test-deploy</image>
 			<image-tag>release</image-tag>
 		</docker-install>
-		<scopes>
-		</scopes>
-		<system>false</system>
 	</external-app>
 </info>

--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -73,6 +73,13 @@ async def init_callback(b_tasks: BackgroundTasks):
 
 def enabled_handler(enabled: bool, _nc: NextcloudApp) -> str:
     print(f"enabled_handler: enabled={bool(enabled)}", flush=True)
+    if torch.version.cuda is not None:
+        torch_version = f"{torch.__version__} (CUDA {torch.version.cuda})"
+    elif torch.version.hip is not None:
+        torch_version = f"{torch.__version__} (ROCm {torch.version.hip})"
+    else:
+        torch_version = torch.__version__
+    print(f"pytorch package version: {torch_version}", flush=True)
     r = ""
     if get_computation_device() == "CUDA":
         print("Get CUDA information", flush=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ preview = true
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-select = ["A", "B", "C", "D", "E", "F", "G", "I", "S", "SIM", "PIE", "Q", "RET", "RUF", "UP" , "W"]
-extend-ignore = ["D101", "D102", "D103", "D105", "D107", "D203", "D213", "D401", "I001", "RUF100", "D400", "D415"]
+lint.select = ["A", "B", "C", "D", "E", "F", "G", "I", "S", "SIM", "PIE", "Q", "RET", "RUF", "UP" , "W"]
+lint.extend-ignore = ["D101", "D102", "D103", "D105", "D107", "D203", "D213", "D401", "I001", "RUF100", "D400", "D415"]
+lint.mccabe.max-complexity = 20
 
 [tool.isort]
 profile = "black"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-nc_py_api[app]>=0.19.2
+nc_py_api[app]>=0.21.1
+httpx


### PR DESCRIPTION
1. Bump PyTorch to `2.8` version
2. Use a full url for base image: `FROM docker.io/python:3.12-slim-bookworm AS builder` 
3. Remove `ADD /ex_app/cs[s] /ex_app/css` syntax that Podman does not support.
4. Add printing info about pytorch in the container logs